### PR TITLE
Fix/opacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+build

--- a/index.js
+++ b/index.js
@@ -461,7 +461,7 @@ function PREPARE(observe) {
         val_stroke[i].innerText = e.target.value;
 
         if (this.id == "bar_alpha") {
-          pipVideoElement.style.opacity = e.target.value * 0.01;
+          zouryouCanvasElement.style.opacity = e.target.value * 0.01;
         }
       },
       false


### PR DESCRIPTION
# #10 不透明度が変化しない  を修正

PiPだとniconicomments側が対応していないので機能しません
(現状の実装だと動画も一緒に薄くなり、PiP表示にすると不透明度100%の状態で表示されます)
一応コマンドに_liveを追加してconfig.contextFillLiveOpacityをいじれば無理やり対応させられますがあまりおすすめしません

## 追記
可能であればniconicommentsを更新していただけるとありがたいです
### 関係ありそうな変更
- v0.2.34でメモリリークを修正しました
- v0.2.38で縁取り色を指定できるようになりました