### PR TITLE
SuperDanmaku・コメントリスト周りの改善

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ function PLAYCOMMENT() {
       comment_list.style.visibility = "hidden";
     });
   LIST_COMMENT();
-  DANMAKU_SUPER();
+  void DANMAKU_SUPER();
   document
     .getElementsByClassName(
       "ActionButton ControllerButton CommentOnOffButton"
@@ -352,7 +352,7 @@ function PLAYCOMMENT() {
   setTimeout(setup, 1000);
 }
 
-function DANMAKU_SUPER() {
+async function DANMAKU_SUPER() {
   let ctx = SuperDanmakuCanvasElement.getContext("2d");
   let net;
   async function loadBodyPix() {
@@ -394,11 +394,10 @@ display:block;-webkit-mask-image: url(${Imagedata});-webkit-mask-size: ${videoEl
     data = SuperDanmakuCanvasElement.toDataURL("image/png");
     mask(data);
   }
-
+  await loadBodyPix();
   setInterval(() => {
     drawCanvas();
   }, 100);
-  loadBodyPix();
 }
 
 function LIST_COMMENT() {

--- a/index.js
+++ b/index.js
@@ -383,10 +383,10 @@ display:block;-webkit-mask-image: url(${Imagedata});-webkit-mask-size: ${videoEl
     return net.segmentPerson(img, option);
   }
   // 绘制帧数据到canvas
-
+  let lastCurrentTime = -1;
   async function drawCanvas() {
-    if (!net) return;
-
+    if (!net || videoElement.currentTime === lastCurrentTime) return;
+    lastCurrentTime = videoElement.currentTime;
     const segmentation = await segmentPerson(videoElement);
 
     const colorMask = bodyPix.toMask(segmentation, false);

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ async function LOADCOMMENT() {
   PLAYCOMMENT();
 }
 
-let niconiComments;
+let niconiComments, comment_list_active;
 
 function PLAYCOMMENT() {
   let draw;
@@ -307,11 +307,13 @@ function PLAYCOMMENT() {
     .getElementById("comment_list_open")
     .addEventListener("click", function () {
       comment_list.style.visibility = "visible";
+      comment_list_active = true;
     });
   document
     .getElementById("comment_list_exit")
     .addEventListener("click", function () {
       comment_list.style.visibility = "hidden";
+      comment_list_active = false;
     });
   LIST_COMMENT();
   void DANMAKU_SUPER();
@@ -408,6 +410,7 @@ function LIST_COMMENT() {
   });
   console.log(COMMENT[0].comments);
   setInterval(() => {
+    if (!comment_list_active)return;
     let passIndex = COMMENT[0].comments.findIndex(function (element) {
       return element.vposMs > Math.floor(videoElement.currentTime * 1000);
     });


### PR DESCRIPTION
- ライブラリの初期化を待つように変更
0.1秒以内に初期化が終わらない可能性を考慮して初期化が完了してからsetIntervalが走るように変更

- 一時停止中などに呼び出しを停止するように変更
同じフレームを何度も分析にかけるのは計算リソースの無駄なのでcurrentTimeが同じであれば更新しないように変更

- コメントリスト非表示中はリストを更新しないように変更
それなりに処理重そうだったので非表示中は処理をスキップするように変更