### PR TITLE
[修正] 投稿者コメントに対応

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ async function LOADCOMMENT(mode) {
     OLD_DATE.value === ""
       ? new Date()
       : new Date(OLD_DATE.value + " " + OLD_TIME.value);
+  const ownerComments = [];
   const comments = [];
   let isLoggedIn = true,
     params = {
@@ -167,7 +168,7 @@ async function LOADCOMMENT(mode) {
           await prepareLegacy();
           continue;
         }
-        comments.push(...res.data.threads[0].comments);
+        (thread.fork==="owner"?ownerComments:comments).push(...res.data.threads[0].comments);
         if (
           res.data.threads[0].comments.length === 0 ||
           res.data.threads[0].comments[0].no < 5
@@ -219,7 +220,7 @@ async function LOADCOMMENT(mode) {
         }
         for (const comment of comments_tmp) {
           //
-          comments.push({
+          (!!comment.user_id ? comments : ownerComments).push({
             body: comment.chat.content,
             commands: comment.chat.mail?.split(/\s+/g),
             id: 0,
@@ -279,6 +280,12 @@ async function LOADCOMMENT(mode) {
       comments: await COMMENT_CONTROL(comments),
       fork: "comment-zouryou",
       id: 0,
+    },
+    {
+      commentCount: ownerComments.length,
+      comments: ownerComments,//投稿者コメントにフィルターを適用する?
+      fork: "owner",
+      id: 1,
     },
   ];
   document.getElementById("reload_niconicomments").onclick = async () => {


### PR DESCRIPTION
niconicommentsへの入力にv1 api形式のコメントデータを使用していますが、その際投稿者判定がうまくできておらず、@置換や@デフォルトなど投稿者用のニコスクリプトが機能していなかったため対応を行いました
一旦投稿者コメントはフィルター対象外にしているので必要に応じて修正をお願いします