### PR TITLE
[修正] 16:9でない画面サイズでの表示を修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -702,7 +702,7 @@ function PREPARE(observe) {
   CustomVideoContainer.style.display = "none";
   CustomVideoContainer.style.zIndex = "1";
   CustomVideoContainer.style.pointerEvents = "none";
-  zouryouCanvasElement.style = `position:absolute;top:0;left:0;width:100%;height:100%;z-index:0;display:block;`;
+  zouryouCanvasElement.style = `position:absolute;top:0;left:0;width:100%;height:100%;z-index:0;display:block;object-fit:contain;`;
   SuperDanmakuCanvasElement.style =
     "position:absolute;top:0;left:0;width:100%;height:100%;z-index:1;display:block;opacity:0;";
   pipVideoElement.style =


### PR DESCRIPTION
フルスクリーン時などcanvas要素が16:9でないサイズに引き伸ばされた際に描画内容も引き伸ばされてしまう問題を修正しました

引き伸ばされている様子
![Screenshot 2023-09-05 at 04-14-02 新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師 - ニコニコ動画](https://github.com/tanbatu/comment-zouryou/assets/96982836/8fcee83a-58f3-4387-b728-9d6defbc5759)
修正後
![Screenshot 2023-09-05 at 04-14-22 新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師 - ニコニコ動画](https://github.com/tanbatu/comment-zouryou/assets/96982836/ea96028c-811b-4277-9bbc-2699d2a6b0c1)
